### PR TITLE
WIP: Add metadata for Versionista to schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,15 +139,17 @@ in addition to the table-specific fields listed below.
   This field is free-form, but we generally expect the following content for a
   given `source_type`:
   * `source_type: 'versionista'`
-    * `account`: The e-mail address for the Versionista account that tracked this version/page
+    * `account`: A string identifying which Versionista account the data came from. This will generally be `versionista1` or `versionista2`.
     * `site_id`: ID of the site in Versionista
     * `page_id`: ID of the page in Versionista
     * `version_id`: ID of the version in Versionista
-    * `page_url`: URL to the Versionista view showing all the versionis of this page
+    * `url`: The full URL to view this version in Versionista. You’ll need to be logged into the appropriate Versionista account to make use of it.
     * `diff_with_previous_url`: URL to diff view in Versionista (comparing with previous version)
+    * `diff_length`: Length (in characters) of the diff identified by the above `diff_with_previous_url`.
+    * `diff_hash`: SHA 256 hash of the above diff identified by `diff_with_previous_url`.
     * `diff_with_first_url`: URL to diff view in Versionista (comparing with the first recorded version)
-    * `diff_length`: Size of the diff in characters
-    * `diff_hash`: Hash of the Versionista-generated diff (identified by `diff_with_previous_url`). This should usually be a SHA 256 hash.
+    * `has_content`: Boolean indicating whether Versionista had raw content for this version. If this is true, the version’s `uri` should have a value (and vice-versa).
+    * `error_code`: If HTTP status code returned to Versionista when it originally scraped the page was a non-200 (OK) status, this property will be present. Its value is the status code of the response, e.g. `403`, `500`, etc.
 
 #### Changes
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,19 @@ in addition to the table-specific fields listed below.
 * uri: path to stored (HTML) data; could be a filepath, S3 bucket, etc.
 * version_hash: sha256 hash of stored data
 * source_type: name of source (such as 'Internet Archive')
-* source_metadata: JSON blob of extra info particular to the source
+* source_metadata: JSON blob of extra info particular to the source.
+  This field is free-form, but we generally expect the following content for a
+  given `source_type`:
+  * `source_type: 'versionista'`
+    * `account`: The e-mail address for the Versionista account that tracked this version/page
+    * `site_id`: ID of the site in Versionista
+    * `page_id`: ID of the page in Versionista
+    * `version_id`: ID of the version in Versionista
+    * `page_url`: URL to the Versionista view showing all the versionis of this page
+    * `diff_with_previous_url`: URL to diff view in Versionista (comparing with previous version)
+    * `diff_with_first_url`: URL to diff view in Versionista (comparing with the first recorded version)
+    * `diff_length`: Size of the diff in characters
+    * `diff_hash`: Hash of the Versionista-generated diff (identified by `diff_with_previous_url`). This should usually be a SHA 256 hash.
 
 #### Changes
 


### PR DESCRIPTION
This is based on the ongoing work in https://github.com/edgi-govdata-archiving/web-monitoring-db/pull/15. The Versionista metadata feels pretty stable and correct even though the rest of that PR is not yet complete.

Marking as **WIP** since we may want to wait until that PR is done before merging this. I don’t think it will be a big deal either way, though—I’m not planning any changes to this part and nobody has said anything about this part on that PR, either.