### PR TITLE
Add “sponsors & partners” section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,15 @@ This project wouldn’t exist without a lot of amazing people’s help. Thanks t
 
 (For a key to the contribution emoji or more info on this format, check out [“All Contributors.”](https://github.com/kentcdodds/all-contributors))
 
+
+## Sponsors & Partners
+
+Finally, we want to give a huge thanks to partner organizations that have helped to support this project with their tools and services:
+
+- [Amazon Web Services](https://aws.amazon.com/)
+- [Sentry.io](https://sentry.io)
+
+
 ## License & Copyright
 
 Copyright (C) 2017 Environmental Data and Governance Initiative (EDGI) <br /> <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/80x15.png" /></a> Web Monitoring documentation is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>. See the [`LICENSE`](https://github.com/edgi-govdata-archiving/web-monitoring/blob/master/LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -234,6 +234,10 @@ Finally, we want to give a huge thanks to partner organizations that have helped
 
 - [Amazon Web Services](https://aws.amazon.com/)
 - [Sentry.io](https://sentry.io)
+- [PageFreezer](https://www.pagefreezer.com)
+- [Google Cloud Platform](https://cloud.google.com)
+- [Google Summer of Code](https://summerofcode.withgoogle.com)
+- [DataKind](http://www.datakind.org/)
 
 
 ## License & Copyright


### PR DESCRIPTION
Adding a section to thank AWS and Sentry for their generous in-kind donations. Is this good? Should the name of the section be different? Am I missing orgs that should also be here?

/cc @weatherpattern @danielballan @dcwalk @titaniumbones 