### PR TITLE
Add stale issue policy

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,18 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 180
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+  - idea
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed in seven days if no further activity occurs. If it should not be closed, please comment! Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
Add a stale issue policy to this repo. The only difference from edgi-govdata-archiving/overview#212 is that we added “idea” as an exempt label (@danielballan was concerned about long-term ideas that we knew wouldn’t be accomplished quickly from the start getting marked as stale).

If we are all 👍 on this I’ll just commit the same directly to `master` on the other web-monitoring repos.