### PR TITLE
Fix broken EDGI website link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ This repository falls under EDGI's [Code of Conduct](https://github.com/edgi-gov
 
 ### Individuals
 
-This project wouldn’t exist without a lot of amazing people’s help. Thanks to the following for their work reviewing URL's, monitoring changes, writing [reports](https://envirodatagov.org/website-monitoring/), and a slew of so many other things!
+This project wouldn’t exist without a lot of amazing people’s help. Thanks to the following for their work reviewing URL's, monitoring changes, writing [reports][webgov], and a slew of so many other things!
 
 <!-- ALL-CONTRIBUTORS-LIST:START -->
 | Contributions | Name |


### PR DESCRIPTION
Fixes #166. Looks like this was missed in #165.