### PR TITLE
Add maintenance status notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 [![Code of Conduct](https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-blue.svg?style=flat)](https://github.com/edgi-govdata-archiving/overview/blob/master/CONDUCT.md) &nbsp;[![Project Status Board](https://img.shields.io/badge/✔-Project%20Status%20Board-green.svg?style=flat)](https://github.com/orgs/edgi-govdata-archiving/projects/4)
 
+
+> **Warning**
+> **This project is no longer actively maintained.** It may receive security updates, but we are no longer making major changes or improvements. EDGI no longer makes active use of this toolset and it is hard to re-deploy in other contexts.
+>
+> - Looking for tools to monitor websites? Check out our [Awesome Website Change Monitoring](https://github.com/edgi-govdata-archiving/awesome-website-change-monitoring) document or [issue #18](https://github.com/edgi-govdata-archiving/web-monitoring/issues/18), which discusses similar projects. *(This project is most useful if monitoring several thousand pages in bulk, but in most cases, other existing tools will solve your needs faster and cheaper.)*
+>
+> - If you have questions about this project or the code, we’re happy to respond! Check out the [Get Involved section](#get-involved) below for information about contacting EDGI members via Slack or e-mail. You can also file an issue on this repo.
+>
+> - **We still actively maintain [Wayback](https://github.com/edgi-govdata-archiving/wayback) and [web-monitoring-diff](https://github.com/edgi-govdata-archiving/web-monitoring-diff).** While we built them as part of this project, they are in wider, more generalized use.
+
+
 # EDGI: Web Monitoring Project
 
 As part of [EDGI's][edgi] [Website Governance Project][webgov] this repository contains tools for monitoring changes to government websites, both environment-related and otherwise. It includes technical tools for:


### PR DESCRIPTION
This is part of #168. EDGI is no longer making active use of the tools here, and they never became generalized to the point where they aren’t a huge amount of effort to deploy and maintain by other organizations or individuals (for example, you need a close partnership with the Internet Archive or another organization that crawls/scrapes/archives the monitored URLs).

The goal here is to make the status of things clear and provide some useful resources for anybody looking at this project.