### PR TITLE
Fix deprecation warning MD syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Code of Conduct](https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-blue.svg?style=flat)](https://github.com/edgi-govdata-archiving/overview/blob/master/CONDUCT.md) &nbsp;[![Project Status Board](https://img.shields.io/badge/✔-Project%20Status%20Board-green.svg?style=flat)](https://github.com/orgs/edgi-govdata-archiving/projects/4)
 
 
-> **Warning**
+> [!WARNING]\
 > **This project is no longer actively maintained.** It may receive security updates, but we are no longer making major changes or improvements. EDGI no longer makes active use of this toolset and it is hard to re-deploy in other contexts.
 >
 > - Looking for tools to monitor websites? Check out our [Awesome Website Change Monitoring](https://github.com/edgi-govdata-archiving/awesome-website-change-monitoring) document or [issue #18](https://github.com/edgi-govdata-archiving/web-monitoring/issues/18), which discusses similar projects. *(This project is most useful if monitoring several thousand pages in bulk, but in most cases, other existing tools will solve your needs faster and cheaper.)*


### PR DESCRIPTION
The special markdown syntax GitHub is using for warning callouts has changed; this updates it to the new syntax.

This *should* work, but apparently the current version does not work in previews (when editing or in PR diffs), so you’ll need to view the file in this branch to see if it’s working correctly.

It’s also possible I should just switch this to a non-specialized syntax. Since the specialized syntax here is non-standard and still marked “beta”, it might not be good to rely on (but it has been supported for over a year, so… 🤷 ).