### PR TITLE
Drop maintenance banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,4 @@
-[![Code of Conduct](https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-blue.svg?style=flat)](https://github.com/edgi-govdata-archiving/overview/blob/main/CONDUCT.md) &nbsp;[![Project Status Board](https://img.shields.io/badge/✔-Project%20Status%20Board-green.svg?style=flat)](https://github.com/orgs/edgi-govdata-archiving/projects/4)
-
-
-> [!WARNING]\
-> **This project is no longer actively maintained.** It may receive security updates, but we are no longer making major changes or improvements. EDGI no longer makes active use of this toolset and it is hard to re-deploy in other contexts.
->
-> - Looking for tools to monitor websites? Check out our [Awesome Website Change Monitoring](https://github.com/edgi-govdata-archiving/awesome-website-change-monitoring) document or [issue #18](https://github.com/edgi-govdata-archiving/web-monitoring/issues/18), which discusses similar projects. *(This project is most useful if monitoring several thousand pages in bulk, but in most cases, other existing tools will solve your needs faster and cheaper.)*
->
-> - If you have questions about this project or the code, we’re happy to respond! Check out the [Get Involved section](#get-involved) below for information about contacting EDGI members via Slack or e-mail. You can also file an issue on this repo.
->
-> - **We still actively maintain [Wayback](https://github.com/edgi-govdata-archiving/wayback) and [web-monitoring-diff](https://github.com/edgi-govdata-archiving/web-monitoring-diff).** While we built them as part of this project, they are in wider, more generalized use.
+[![Code of Conduct](https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-blue.svg?style=flat)](https://github.com/edgi-govdata-archiving/overview/blob/main/CONDUCT.md) &nbsp;[![Project Status Board](https://img.shields.io/badge/✔-Project%20Status%20Board-green.svg?style=flat)](https://github.com/orgs/edgi-govdata-archiving/projects/32)
 
 
 # EDGI: Web Monitoring Project


### PR DESCRIPTION
The project is operational again, so the not-actively-maintained banner in the README is no longer accurate. This also updates the project board link to the correct URL.

Part of #174.