### PR TITLE
The "good first issue" label is now dashless

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This project is two-part! We rely both on **open source code contributors** (bui
 * Be sure to check our [contributor guidelines](https://github.com/edgi-govdata-archiving/web-monitoring/blob/main/CONTRIBUTING.md).
 * Take a look through the repos listed in the [Project Structure](#project-structure) section and choose one that feels appropriate to your interests and skillset.
 * Try to get a repo running on your machine (and if you have any challenges, please make issues about them!).
-* Find an issue labeled `good-first-issue` and work to resolve it.
+* Find an issue labeled `good first issue` and work to resolve it.
 
 
 ## Project Overview


### PR DESCRIPTION
We've now standardized issue labels to be `help wanted` and `good first issue` (no dashes) across all repos. This updates docs to direct people to the right labels.